### PR TITLE
Fix checkmark formatter url

### DIFF
--- a/vendor/assets/javascripts/slick/formatters.js
+++ b/vendor/assets/javascripts/slick/formatters.js
@@ -50,6 +50,6 @@
   }
 
   function CheckmarkFormatter(row, cell, value, columnDef, dataContext) {
-    return value ? "<img src='../images/tick.png'>" : "";
+    return value ? "<img src='/assets/slick/tick.png'>" : "";
   }
 })(jQuery);


### PR DESCRIPTION
Previously, the checkmark formatter returned the wrong image path.
Ideally, we'd use an asset path helper, but that would require a
bigger change, and this is good enough I think.
